### PR TITLE
[FEAT] 로컬에선 일반 형식, 서버에선 Json 형식 로그 사용. 데이터독 로그 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.1.3'
     // AWS secret manager
     implementation 'org.springframework.cloud:spring-cloud-starter-aws-secrets-manager-config:2.2.6.RELEASE'
+    // Json format log encoder
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.2'
 }
 
 jar{

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,4 +19,4 @@ echo "> $JAR_NAME 에 실행권한 추가"
 chmod +x $JAR_NAME
 
 echo "> $JAR_NAME 실행"
-nohup /opt/jdk-17/bin/java -javaagent:$DATADOG -Ddd.logs.injection=true -jar -Dspring.profiles.active=server $JAR_NAME > $REPOSITORY/nohup.out &
+nohup /opt/jdk-17/bin/java -javaagent:$DATADOG -Ddd.logs.injection=true -jar -Dspring.profiles.active=server $JAR_NAME > $REPOSITORY/nohup.out 2>&1 &

--- a/src/main/java/com/lolduo/duo/service/RiotService.java
+++ b/src/main/java/com/lolduo/duo/service/RiotService.java
@@ -71,8 +71,8 @@ public class RiotService implements ApplicationRunner{
         setChampion();
         setSpell();
         setPerk();
-        //All();
-        test();
+        All();
+        //test();
     }
     public void test(){
         String[] st = {"KR_6048833978",

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- By default, encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-3level %logger{5} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- By default, encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="STDOUT"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="server">
+        <root level="INFO">
+            <appender-ref ref="STDOUT_JSON"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
1. logback-spring.xml 파일 설정으로 로컬과 서버 로그 형식 분리
2. codedeploy에서 실패 뜨지 않도록 deploy.sh 수정
3. RiotService에서 test() 주석 처리, All() 주석 제거