### PR TITLE
Fix/search champion info

### DIFF
--- a/src/main/java/com/lolduo/duo/repository/clientInfo/DuoInfoRepository.java
+++ b/src/main/java/com/lolduo/duo/repository/clientInfo/DuoInfoRepository.java
@@ -9,10 +9,10 @@ import java.util.Optional;
 
 public interface DuoInfoRepository extends JpaRepository<DuoInfoEntity,Long>, ICombinationInfoRepository {
 
-    @Query(value = "select * from duo_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count DESC limit 30",nativeQuery = true)
+    @Query(value = "select * from duo_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count DESC limit 100",nativeQuery = true)
     Optional<List<DuoInfoEntity>> findAllByChampionIdAndPositionDesc(String championId, String position);
 
-    @Query(value = "select * from duo_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count ASC limit 30",nativeQuery = true)
+    @Query(value = "select * from duo_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count ASC limit 100",nativeQuery = true)
     Optional<List<DuoInfoEntity>> findAllByChampionIdAndPositionAsc(String championId, String position);
 
     @Query(value = "select * from duo_info where json_contains(champion_id,?1) and json_contains(position,?2)",nativeQuery = true)

--- a/src/main/java/com/lolduo/duo/repository/clientInfo/QuintetInfoRepository.java
+++ b/src/main/java/com/lolduo/duo/repository/clientInfo/QuintetInfoRepository.java
@@ -8,10 +8,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface QuintetInfoRepository extends JpaRepository<QuintetInfoEntity,Long>, ICombinationInfoRepository {
-    @Query(value = "select * from quintet_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count DESC limit 30",nativeQuery = true)
+    @Query(value = "select * from quintet_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count DESC limit 100",nativeQuery = true)
     Optional<List<QuintetInfoEntity>> findAllByChampionIdAndPositionDesc(String championId, String position);
 
-    @Query(value = "select * from quintet_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count ASC limit 30",nativeQuery = true)
+    @Query(value = "select * from quintet_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count ASC limit 100",nativeQuery = true)
     Optional<List<QuintetInfoEntity>> findAllByChampionIdAndPositionAsc(String championId, String position);
 
     @Query(value = "select * from quintet_info where json_contains(champion_id,?1) and json_contains(position,?2)",nativeQuery = true)

--- a/src/main/java/com/lolduo/duo/repository/clientInfo/TrioInfoRepository.java
+++ b/src/main/java/com/lolduo/duo/repository/clientInfo/TrioInfoRepository.java
@@ -8,10 +8,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TrioInfoRepository extends JpaRepository<TrioInfoEntity,Long>, ICombinationInfoRepository {
-    @Query(value = "select * from trio_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count DESC limit 30",nativeQuery = true)
+    @Query(value = "select * from trio_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count DESC limit 100",nativeQuery = true)
     Optional<List<TrioInfoEntity>> findAllByChampionIdAndPositionDesc(String championId, String position);
 
-    @Query(value = "select * from trio_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count ASC limit 30",nativeQuery = true)
+    @Query(value = "select * from trio_info where json_contains(champion_id,?1) and json_contains(position,?2) order by win_count / all_count ASC limit 100",nativeQuery = true)
     Optional<List<TrioInfoEntity>> findAllByChampionIdAndPositionAsc(String championId, String position);
 
     @Query(value = "select * from trio_info where json_contains(champion_id,?1) and json_contains(position,?2)",nativeQuery = true)

--- a/src/main/java/com/lolduo/duo/service/ClientService.java
+++ b/src/main/java/com/lolduo/duo/service/ClientService.java
@@ -120,7 +120,7 @@ public class ClientService {
                 log.info("getChampionInfoList() - 매치 데이터 검색.\n검색 championId = {}\n검색 position = {}",
                         objectMapper.writeValueAsString(championIdSet), objectMapper.writeValueAsString(positionMap));
 
-                if (infoEntityList != null) {
+                if (infoEntityList != null && !infoEntityList.isEmpty()) {
                     log.info("getChampionInfoList() - 검색 결과.");
 
                     infoEntityList.forEach(infoEntity -> {


### PR DESCRIPTION
1. DB에 없는 조합 검색 시 []만 반환하는 문제 수정
2. 0챔피언에 포지션 지정 시 다른 챔피언들이 해당 포지션에 지정된 행들은 결과에서 제외
* 0챔피언에 포지션 지정했을 때 위 2번 이외에는 결과에 아직 영향을 주지 않음. 추가 구현 필요.